### PR TITLE
chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,231 @@ Here are some ideas to get you started:
 - ⚡ Fun fact: ...
 -->
 my life in what I do I'm tryingtokeep  things goingbutbinn keepbmhb*>iivon ghrbr rightb
+Skip to Main Content
+Documentation
+MySQL Server
+ 
+MySQL Enterprise
+ 
+Workbench
+ 
+InnoDB Cluster
+ 
+MySQL NDB Cluster
+ 
+Connectors
+ 
+More
+MySQL.com
+Downloads
+Developer Zone
+Search this Manual
+ 
+Related Documentation
+MySQL 8.4 Release Notes
+Download this Manual
+PDF (US Ltr) - 40.0Mb
+PDF (A4) - 40.0Mb
+Man Pages (TGZ) - 258.6Kb
+Man Pages (Zip) - 365.7Kb
+Info (Gzip) - 4.0Mb
+Info (Zip) - 4.0Mb
+
+
+version 8.4 
+MySQL 8.4 Reference Manual  /  ...  /  Initializing the Data Directory
+2.9.1 Initializing the Data Directory
+After MySQL is installed, the data directory must be initialized, including the tables in the mysql system schema:
+
+For some MySQL installation methods, data directory initialization is automatic, as described in Section 2.9, “Postinstallation Setup and Testing”.
+
+For other installation methods, you must initialize the data directory manually. These include installation from generic binary and source distributions on Unix and Unix-like systems, and installation from a ZIP Archive package on Windows.
+
+This section describes how to initialize the data directory manually for MySQL installation methods for which data directory initialization is not automatic. For some suggested commands that enable testing whether the server is accessible and working properly, see Section 2.9.3, “Testing the Server”.
+
+Note
+The default authentication plugin is caching_sha2_password, and the 'root'@'localhost' administrative account uses caching_sha2_password by default.
+
+mysql_native_password (the default authentication plugin prior to MySQL 8.0) is still supported but disabled by default as of MySQL 8.4.0 and removed as of MySQL 9.0.0.
+
+Data Directory Initialization Overview
+
+Data Directory Initialization Procedure
+
+Server Actions During Data Directory Initialization
+
+Post-Initialization root Password Assignment
+
+Data Directory Initialization Overview
+In the examples shown here, the server is intended to run under the user ID of the mysql login account. Either create the account if it does not exist (see Create a mysql User and Group), or substitute the name of a different existing login account that you plan to use for running the server.
+
+Change location to the top-level directory of your MySQL installation, which is typically /usr/local/mysql (adjust the path name for your system as necessary):
+
+cd /usr/local/mysql
+Within this directory you can find several files and subdirectories, including the bin subdirectory that contains the server, as well as client and utility programs.
+
+The secure_file_priv system variable limits import and export operations to a specific directory. Create a directory whose location can be specified as the value of that variable:
+
+mkdir mysql-files
+Grant directory user and group ownership to the mysql user and mysql group, and set the directory permissions appropriately:
+
+chown mysql:mysql mysql-files
+chmod 750 mysql-files
+Use the server to initialize the data directory, including the mysql schema containing the initial MySQL grant tables that determine how users are permitted to connect to the server. For example:
+
+bin/mysqld --initialize --user=mysql
+For important information about the command, especially regarding command options you might use, see Data Directory Initialization Procedure. For details about how the server performs initialization, see Server Actions During Data Directory Initialization.
+
+Typically, data directory initialization need be done only after you first install MySQL. (For upgrades to an existing installation, perform the upgrade procedure instead; see Chapter 3, Upgrading MySQL.) However, the command that initializes the data directory does not overwrite any existing mysql schema tables, so it is safe to run in any circumstances.
+
+In the absence of any option files, the server starts with its default settings. (See Section 7.1.2, “Server Configuration Defaults”.) To explicitly specify options that the MySQL server should use at startup, put them in an option file such as /etc/my.cnf or /etc/mysql/my.cnf. (See Section 6.2.2.2, “Using Option Files”.) For example, you can use an option file to set the secure_file_priv system variable.
+
+To arrange for MySQL to start without manual intervention at system boot time, see Section 2.9.5, “Starting and Stopping MySQL Automatically”.
+
+Data directory initialization creates time zone tables in the mysql schema but does not populate them. To do so, use the instructions in Section 7.1.15, “MySQL Server Time Zone Support”.
+
+Data Directory Initialization Procedure
+Change location to the top-level directory of your MySQL installation, which is typically /usr/local/mysql (adjust the path name for your system as necessary):
+
+cd /usr/local/mysql
+To initialize the data directory, invoke mysqld with the --initialize or --initialize-insecure option, depending on whether you want the server to generate a random initial password for the 'root'@'localhost' account, or to create that account with no password:
+
+Use --initialize for “secure by default” installation (that is, including generation of a random initial root password). In this case, the password is marked as expired and you must choose a new one.
+
+With --initialize-insecure, no root password is generated. This is insecure; it is assumed that you intend to assign a password to the account in a timely fashion before putting the server into production use.
+
+For instructions on assigning a new 'root'@'localhost' password, see Post-Initialization root Password Assignment.
+
+Note
+The server writes any messages (including any initial password) to its standard error output. This may be redirected to the error log, so look there if you do not see the messages on your screen. For information about the error log, including where it is located, see Section 7.4.2, “The Error Log”.
+
+On Windows, use the --console option to direct messages to the console.
+
+On Unix and Unix-like systems, it is important for the database directories and files to be owned by the mysql login account so that the server has read and write access to them when you run it later. To ensure this, start mysqld from the system root account and include the --user option as shown here:
+
+bin/mysqld --initialize --user=mysql
+bin/mysqld --initialize-insecure --user=mysql
+Alternatively, execute mysqld while logged in as mysql, in which case you can omit the --user option from the command.
+
+On Windows, use one of these commands:
+
+bin\mysqld --initialize --console
+bin\mysqld --initialize-insecure --console
+Note
+Data directory initialization might fail if required system libraries are missing. For example, you might see an error like this:
+
+bin/mysqld: error while loading shared libraries:
+libnuma.so.1: cannot open shared object file:
+No such file or directory
+If this happens, you must install the missing libraries manually or with your system's package manager. Then retry the data directory initialization command.
+
+It might be necessary to specify other options such as --basedir or --datadir if mysqld cannot identify the correct locations for the installation directory or data directory. For example (enter the command on a single line):
+
+bin/mysqld --initialize --user=mysql
+  --basedir=/opt/mysql/mysql
+  --datadir=/opt/mysql/mysql/data
+Alternatively, put the relevant option settings in an option file and pass the name of that file to mysqld. For Unix and Unix-like systems, suppose that the option file name is /opt/mysql/mysql/etc/my.cnf. Put these lines in the file:
+
+[mysqld]
+basedir=/opt/mysql/mysql
+datadir=/opt/mysql/mysql/data
+Then invoke mysqld as follows (enter the command on a single line, with the --defaults-file option first):
+
+bin/mysqld --defaults-file=/opt/mysql/mysql/etc/my.cnf
+  --initialize --user=mysql
+On Windows, suppose that C:\my.ini contains these lines:
+
+[mysqld]
+basedir=C:\\Program Files\\MySQL\\MySQL Server 8.4
+datadir=D:\\MySQLdata
+Then invoke mysqld as follows (again, you should enter the command on a single line, with the --defaults-file option first):
+
+bin\mysqld --defaults-file=C:\my.ini
+   --initialize --console
+Important
+When initializing the data directory, you should not specify any options other than those used for setting directory locations such as --basedir or --datadir, and the --user option if needed. Options to be employed by the MySQL server during normal use can be set when restarting it following initialization. See the description of the --initialize option for further information.
+
+Server Actions During Data Directory Initialization
+Note
+The data directory initialization sequence performed by the server does not substitute for the actions performed by mysql_secure_installation.
+
+When invoked with the --initialize or --initialize-insecure option, mysqld performs the following actions during the data directory initialization sequence:
+
+The server checks for the existence of the data directory as follows:
+
+If no data directory exists, the server creates it.
+
+If the data directory exists but is not empty (that is, it contains files or subdirectories), the server exits after producing an error message:
+
+[ERROR] --initialize specified but the data directory exists. Aborting.
+In this case, remove or rename the data directory and try again.
+
+An existing data directory is permitted to be nonempty if every entry has a name that begins with a period (.).
+
+Within the data directory, the server creates the mysql system schema and its tables, including the data dictionary tables, grant tables, time zone tables, and server-side help tables. See Section 7.3, “The mysql System Schema”.
+
+The server initializes the system tablespace and related data structures needed to manage InnoDB tables.
+
+Note
+After mysqld sets up the InnoDB system tablespace, certain changes to tablespace characteristics require setting up a whole new instance. Qualifying changes include the file name of the first file in the system tablespace and the number of undo logs. If you do not want to use the default values, make sure that the settings for the innodb_data_file_path and innodb_log_file_size configuration parameters are in place in the MySQL configuration file before running mysqld. Also make sure to specify as necessary other parameters that affect the creation and location of InnoDB files, such as innodb_data_home_dir and innodb_log_group_home_dir.
+
+If those options are in your configuration file but that file is not in a location that MySQL reads by default, specify the file location using the --defaults-extra-file option when you run mysqld.
+
+The server creates a 'root'@'localhost' superuser account and other reserved accounts (see Section 8.2.9, “Reserved Accounts”). Some reserved accounts are locked and cannot be used by clients, but 'root'@'localhost' is intended for administrative use and you should assign it a password.
+
+Server actions with respect to a password for the 'root'@'localhost' account depend on how you invoke it:
+
+With --initialize but not --initialize-insecure, the server generates a random password, marks it as expired, and writes a message displaying the password:
+
+[Warning] A temporary password is generated for root@localhost:
+iTag*AfrH5ej
+With --initialize-insecure, (either with or without --initialize because --initialize-insecure implies --initialize), the server does not generate a password or mark it expired, and writes a warning message:
+
+[Warning] root@localhost is created with an empty password ! Please
+consider switching off the --initialize-insecure option.
+For instructions on assigning a new 'root'@'localhost' password, see Post-Initialization root Password Assignment.
+
+The server populates the server-side help tables used for the HELP statement (see Section 15.8.3, “HELP Statement”). The server does not populate the time zone tables. To do so manually, see Section 7.1.15, “MySQL Server Time Zone Support”.
+
+If the init_file system variable was given to name a file of SQL statements, the server executes the statements in the file. This option enables you to perform custom bootstrapping sequences.
+
+When the server operates in bootstrap mode, some functionality is unavailable that limits the statements permitted in the file. These include statements that relate to account management (such as CREATE USER or GRANT), replication, and global transaction identifiers.
+
+The server exits.
+
+Post-Initialization root Password Assignment
+After you initialize the data directory by starting the server with --initialize or --initialize-insecure, start the server normally (that is, without either of those options) and assign the 'root'@'localhost' account a new password:
+
+Start the server. For instructions, see Section 2.9.2, “Starting the Server”.
+
+Connect to the server:
+
+If you used --initialize but not --initialize-insecure to initialize the data directory, connect to the server as root:
+
+mysql -u root -p
+Then, at the password prompt, enter the random password that the server generated during the initialization sequence:
+
+Enter password: (enter the random root password here)
+Look in the server error log if you do not know this password.
+
+If you used --initialize-insecure to initialize the data directory, connect to the server as root without a password:
+
+mysql -u root --skip-password
+After connecting, use an ALTER USER statement to assign a new root password:
+
+ALTER USER 'root'@'localhost' IDENTIFIED BY 'root-password';
+See also Section 2.9.4, “Securing the Initial MySQL Account”.
+
+Note
+Attempts to connect to the host 127.0.0.1 normally resolve to the localhost account. However, this fails if the server is run with skip_name_resolve enabled. If you plan to do that, make sure that an account exists that can accept a connection. For example, to be able to connect as root using --host=127.0.0.1 or --host=::1, create these accounts:
+
+CREATE USER 'root'@'127.0.0.1' IDENTIFIED BY 'root-password';
+CREATE USER 'root'@'::1' IDENTIFIED BY 'root-password';
+It is possible to put those statements in a file to be executed using the init_file system variable, as discussed in Server Actions During Data Directory Initialization.
+
+
+ PREV   HOME   UP   NEXT 
+Related Documentation
+Download this Manual
+   © 2024 Oracle
+   


### PR DESCRIPTION
Git--fast-version-control
Type / to search entire site…
About
Documentation
Reference
Book
Videos
External Links
Downloads
Community
English ▾Topics ▾Latest version ▾
gitignore last updated in 2.42.0
NAME
gitignore - Specifies intentionally untracked files to ignore

SYNOPSIS
$XDG_CONFIG_HOME/git/ignore, $GIT_DIR/info/exclude, .gitignore

DESCRIPTION
A gitignore file specifies intentionally untracked files that Git should ignore. Files already tracked by Git are not affected; see the NOTES below for details.

Each line in a gitignore file specifies a pattern. When deciding whether to ignore a path, Git normally checks gitignore patterns from multiple sources, with the following order of precedence, from highest to lowest (within one level of precedence, the last matching pattern decides the outcome):

Patterns read from the command line for those commands that support them.

Patterns read from a .gitignore file in the same directory as the path, or in any parent directory (up to the top-level of the working tree), with patterns in the higher level files being overridden by those in lower level files down to the directory containing the file. These patterns match relative to the location of the .gitignore file. A project normally includes such .gitignore files in its repository, containing patterns for files generated as part of the project build.

Patterns read from $GIT_DIR/info/exclude.

Patterns read from the file specified by the configuration variable core.excludesFile.

Which file to place a pattern in depends on how the pattern is meant to be used.

Patterns which should be version-controlled and distributed to other repositories via clone (i.e., files that all developers will want to ignore) should go into a .gitignore file.

Patterns which are specific to a particular repository but which do not need to be shared with other related repositories (e.g., auxiliary files that live inside the repository but are specific to one user’s workflow) should go into the $GIT_DIR/info/exclude file.

Patterns which a user wants Git to ignore in all situations (e.g., backup or temporary files generated by the user’s editor of choice) generally go into a file specified by core.excludesFile in the user’s ~/.gitconfig. Its default value is $XDG_CONFIG_HOME/git/ignore. If $XDG_CONFIG_HOME is either not set or empty, $HOME/.config/git/ignore is used instead.

The underlying Git plumbing tools, such as git ls-files and git read-tree, read gitignore patterns specified by command-line options, or from files specified by command-line options. Higher-level Git tools, such as git status and git add, use patterns from the sources specified above.

PATTERN FORMAT
A blank line matches no files, so it can serve as a separator for readability.

A line starting with # serves as a comment. Put a backslash ("\") in front of the first hash for patterns that begin with a hash.

Trailing spaces are ignored unless they are quoted with backslash ("\").

An optional prefix "!" which negates the pattern; any matching file excluded by a previous pattern will become included again. It is not possible to re-include a file if a parent directory of that file is excluded. Git doesn’t list excluded directories for performance reasons, so any patterns on contained files have no effect, no matter where they are defined. Put a backslash ("\") in front of the first "!" for patterns that begin with a literal "!", for example, "\!important!.txt".

The slash "/" is used as the directory separator. Separators may occur at the beginning, middle or end of the .gitignore search pattern.

If there is a separator at the beginning or middle (or both) of the pattern, then the pattern is relative to the directory level of the particular .gitignore file itself. Otherwise the pattern may also match at any level below the .gitignore level.

If there is a separator at the end of the pattern then the pattern will only match directories, otherwise the pattern can match both files and directories.

For example, a pattern doc/frotz/ matches doc/frotz directory, but not a/doc/frotz directory; however frotz/ matches frotz and a/frotz that is a directory (all paths are relative from the .gitignore file).

An asterisk "*" matches anything except a slash. The character "?" matches any one character except "/". The range notation, e.g. [a-zA-Z], can be used to match one of the characters in a range. See fnmatch(3) and the FNM_PATHNAME flag for a more detailed description.

Two consecutive asterisks ("**") in patterns matched against full pathname may have special meaning:

A leading "**" followed by a slash means match in all directories. For example, "**/foo" matches file or directory "foo" anywhere, the same as pattern "foo". "**/foo/bar" matches file or directory "bar" anywhere that is directly under directory "foo".

A trailing "/**" matches everything inside. For example, "abc/**" matches all files inside directory "abc", relative to the location of the .gitignore file, with infinite depth.

A slash followed by two consecutive asterisks then a slash matches zero or more directories. For example, "a/**/b" matches "a/b", "a/x/b", "a/x/y/b" and so on.

Other consecutive asterisks are considered regular asterisks and will match according to the previous rules.

CONFIGURATION
The optional configuration variable core.excludesFile indicates a path to a file containing patterns of file names to exclude, similar to $GIT_DIR/info/exclude. Patterns in the exclude file are used in addition to those in $GIT_DIR/info/exclude.

NOTES
The purpose of gitignore files is to ensure that certain files not tracked by Git remain untracked.

To stop tracking a file that is currently tracked, use git rm --cached to remove the file from the index. The filename can then be added to the .gitignore file to stop the file from being reintroduced in later commits.

Git does not follow symbolic links when accessing a .gitignore file in the working tree. This keeps behavior consistent when the file is accessed from the index or a tree versus from the filesystem.

EXAMPLES
The pattern hello.* matches any file or directory whose name begins with hello.. If one wants to restrict this only to the directory and not in its subdirectories, one can prepend the pattern with a slash, i.e. /hello.*; the pattern now matches hello.txt, hello.c but not a/hello.java.

The pattern foo/ will match a directory foo and paths underneath it, but will not match a regular file or a symbolic link foo (this is consistent with the way how pathspec works in general in Git)

The pattern doc/frotz and /doc/frotz have the same effect in any .gitignore file. In other words, a leading slash is not relevant if there is already a middle slash in the pattern.

The pattern foo/*, matches foo/test.json (a regular file), foo/bar (a directory), but it does not match foo/bar/hello.c (a regular file), as the asterisk in the pattern does not match bar/hello.c which has a slash in it.

    $ git status
    [...]
    # Untracked files:
    [...]
    #       Documentation/foo.html
    #       Documentation/gitignore.html
    #       file.o
    #       lib.a
    #       src/internal.o
    [...]
    $ cat .git/info/exclude
    # ignore objects and archives, anywhere in the tree.
    *.[oa]
    $ cat Documentation/.gitignore
    # ignore generated html files,
    *.html
    # except foo.html which is maintained by hand
    !foo.html
    $ git status
    [...]
    # Untracked files:
    [...]
    #       Documentation/foo.html
    [...]
Another example:

    $ cat .gitignore
    vmlinux*
    $ ls arch/foo/kernel/vm*
    arch/foo/kernel/vmlinux.lds.S
    $ echo '!/vmlinux*' >arch/foo/kernel/.gitignore
The second .gitignore prevents Git from ignoring arch/foo/kernel/vmlinux.lds.S.

Example to exclude everything except a specific directory foo/bar (note the /* - without the slash, the wildcard would also exclude everything within foo/bar):

    $ cat .gitignore
    # exclude everything except directory foo/bar
    /*
    !/foo
    /foo/*
    !/foo/bar
SEE ALSO
git-rm[1], gitrepository-layout[5], git-check-ignore[1]

GIT
Part of the git[1] suite

About this site
Patches, suggestions, and comments are welcome.
Git is a member of Software Freedom Conservancy
scroll-to-top